### PR TITLE
Add missing official runtime files

### DIFF
--- a/compiler/se.vim
+++ b/compiler/se.vim
@@ -1,0 +1,31 @@
+" Vim compiler file
+" Compiler:	se (Liberty Eiffel Compiler)
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2013 Jun 29
+" URL:		https://github.com/eiffelhub/vim-eiffel
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "se"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+CompilerSet makeprg=se\ c
+
+CompilerSet errorformat=%W******\ Warning:\ %m,
+		    \%E******\ Fatal\ Error:\ %m,
+		    \%E******\ Error:\ %m,
+		    \%ZLine\ %l\ column\ %c\ in\ %.%#\ (%f)\ %\\=:,
+		    \%ZLine\ %l\ columns\ %c\\,\ %\\d%\\+\ %.%#\ (%f)\ %\\=:,
+		    \%+C%*[^\ ]%.%#,
+		    \%-GThe\ source\ lines\ involved,
+		    \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/eiffel.vim
+++ b/ftplugin/eiffel.vim
@@ -1,28 +1,97 @@
-" Vim filetype plugin file
+" Vim filetype plugin
 " Language:	Eiffel
-" Maintainer:	Jocelyn Fiat <jfiat@eiffel.com>
-" 				(https://github.com/eiffelhub/vim-eiffel)
-" URL: https://github.com/eiffelhub/vim-eiffel
-" Last Change:	Tue 22 Apr 2003 09:50:08
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2010 Aug 29
+" URL:		https://github.com/eiffelhub/vim-eiffel
 
-" Only do this when not done yet for this buffer
-if exists("b:did_ftplugin")
+if (exists("b:did_ftplugin"))
   finish
 endif
-
-" Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-" Matchit handling
+let s:cpo_save = &cpo
+set cpo&vim
 
-" The following lines enable the macros/matchit.vim plugin for
-" extended matching with the % key.
+setlocal comments=:--
+setlocal commentstring=--\ %s
 
-if exists("loaded_matchit")
+setlocal formatoptions-=t formatoptions+=croql
 
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Eiffel Source Files (*.e)\t*.e\n" .
+		     \ "Eiffel Control Files (*.ecf, *.ace, *.xace)\t*.ecf;*.ace;*.xace\n" .
+		     \ "All Files (*.*)\t*.*\n"
+endif
+
+if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
-  if !exists("b:match_words") |
-    let b:match_words = '\<\%(do\|if\|from\|check\|inspect\)\>:' . '\<\%(else\|elseif\|until\|loop\|when\):'. '\<end\>'
-  endif
+  " Silly \%^ trick to match note at head of pair and in middle prevents
+  " 'g%' wrapping from 'note' to 'end'
+  let b:match_words = '\%^:' .
+		  \	'\<\%(^note\|indexing\|class\|^obsolete\|inherit\|insert\|^create\|convert\|feature\|^invariant\)\>:' .
+		  \   '^end\>,' .
+		  \   '\<\%(do\|deferred\|external\|once\%(\s\+"\)\@!\|check\|debug\|if\|inspect\|from\|across\)\>:' .
+		  \	'\%(\%(^\s\+\)\@<=\%(then\|until\|loop\)\|\%(then\|until\|loop\)\s\+[^ -]\|' .
+		  \	'\<\%(ensure\%(\s\+then\)\=\|rescue\|_then\|elseif\|else\|when\|\s\@<=invariant\|_until\|_loop\|variant\|_as\|alias\)\>\):' .
+		  \   '\s\@<=end\>'
+  let b:match_skip = 's:\<eiffel\%(Comment\|String\|Operator\)\>'
+  noremap  [% <Nop>
+  noremap  ]% <Nop>
+  vnoremap a% <Nop>
+endif
 
-endif " exists("loaded_matchit")
+let b:undo_ftplugin = "setl fo< com< cms<" .
+  \ "| unlet! b:browsefilter b:match_ignorecase b:match_words b:match_skip"
+
+if !exists("g:no_plugin_maps") && !exists("g:no_eiffel_maps")
+  function! s:DoMotion(pattern, count, flags) abort
+    normal! m'
+    for i in range(a:count)
+      call search(a:pattern, a:flags)
+    endfor
+  endfunction
+
+  let sections = '^\%(note\|indexing\|' .
+	     \	 '\%(\%(deferred\|expanded\|external\|frozen\)\s\+\)*class\|' .
+	     \	 'obsolete\|inherit\|insert\|create\|convert\|feature\|' .
+	     \	 'invariant\|end\)\>'
+
+  nnoremap <silent> <buffer> ]] :<C-U>call <SID>DoMotion(sections, v:count1, 'W')<CR>
+  xnoremap <silent> <buffer> ]] :<C-U>exe "normal! gv"<Bar>call <SID>DoMotion(sections, v:count1, 'W')<CR>
+  nnoremap <silent> <buffer> [[ :<C-U>call <SID>DoMotion(sections, v:count1, 'Wb')<CR>
+  xnoremap <silent> <buffer> [[ :<C-U>exe "normal! gv"<Bar>call <SID>DoMotion(sections, v:count1, 'Wb')<CR>
+
+  function! s:DoFeatureMotion(count, flags)
+    let view = winsaveview()
+    call cursor(1, 1)
+    let [features_start, _] = searchpos('^feature\>')
+    call search('^\s\+\a') " find the first feature
+    let spaces = indent(line('.'))
+    let [features_end, _] = searchpos('^\%(invariant\|note\|end\)\>')
+    call winrestview(view)
+    call s:DoMotion('\%>' . features_start . 'l\%<' . features_end . 'l^\s*\%' . (spaces + 1) . 'v\zs\a', a:count, a:flags)
+  endfunction
+
+  nnoremap <silent> <buffer> ]m :<C-U>call <SID>DoFeatureMotion(v:count1, 'W')<CR>
+  xnoremap <silent> <buffer> ]m :<C-U>exe "normal! gv"<Bar>call <SID>DoFeatureMotion(v:count1, 'W')<CR>
+  nnoremap <silent> <buffer> [m :<C-U>call <SID>DoFeatureMotion(v:count1, 'Wb')<CR>
+  xnoremap <silent> <buffer> [m :<C-U>exe "normal! gv"<Bar>call <SID>DoFeatureMotion(v:count1, 'Wb')<CR>
+
+  let comment_block_start = '^\%(\s\+--.*\n\)\@<!\s\+--'
+  let comment_block_end = '^\s\+--.*\n\%(\s\+--\)\@!'
+
+  nnoremap <silent> <buffer> ]- :<C-U>call <SID>DoMotion(comment_block_start, 1, 'W')<CR>
+  xnoremap <silent> <buffer> ]- :<C-U>exe "normal! gv"<Bar>call <SID>DoMotion(comment_block_start, 1, 'W')<CR>
+  nnoremap <silent> <buffer> [- :<C-U>call <SID>DoMotion(comment_block_end, 1, 'Wb')<CR>
+  xnoremap <silent> <buffer> [- :<C-U>exe "normal! gv"<Bar>call <SID>DoMotion(comment_block_end, 1, 'Wb')<CR>
+
+  let b:undo_ftplugin = b:undo_ftplugin .
+    \ "| silent! execute 'unmap <buffer> [[' | silent! execute 'unmap <buffer> ]]'" .
+    \ "| silent! execute 'unmap <buffer> [m' | silent! execute 'unmap <buffer> ]m'" .
+    \ "| silent! execute 'unmap <buffer> [-' | silent! execute 'unmap <buffer> ]-'"
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8

--- a/syntax/lace.vim
+++ b/syntax/lace.vim
@@ -1,0 +1,136 @@
+" Vim syntax file
+" Language:		lace
+" Maintainer:	Jocelyn Fiat <utilities@eiffel.com>
+" Last Change:	2001 May 09
+" URL:			https://github.com/eiffelhub/vim-eiffel
+
+" Copyright Interactive Software Engineering, 1998
+" You are free to use this file as you please, but
+" if you make a change or improvement you must send
+" it to the maintainer at <utilities@eiffel.com>
+
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+" LACE is case insensitive, but the style guide lines are not.
+
+if !exists("lace_case_insensitive")
+	syn case match
+else
+	syn case ignore
+endif
+
+" A bunch of useful LACE keywords
+syn keyword laceTopStruct		system root default option visible cluster
+syn keyword laceTopStruct		external generate end
+syn keyword laceOptionClause	collect assertion debug optimize trace
+syn keyword laceOptionClause	profile inline precompiled multithreaded
+syn keyword laceOptionClause	exception_trace dead_code_removal
+syn keyword laceOptionClause	array_optimization
+syn keyword laceOptionClause	inlining_size inlining
+syn keyword laceOptionClause	console_application dynamic_runtime
+syn keyword laceOptionClause	line_generation
+syn keyword laceOptionMark		yes no all
+syn keyword laceOptionMark		require ensure invariant loop check
+syn keyword laceClusterProp		use include exclude
+syn keyword laceAdaptClassName	adapt ignore rename as
+syn keyword laceAdaptClassName	creation export visible
+syn keyword laceExternal		include_path object makefile
+
+" Operators
+syn match   laceOperator		"\$"
+syn match   laceBrackets		"[[\]]"
+syn match   laceExport			"[{}]"
+
+" Constants
+syn keyword laceBool		true false
+syn keyword laceBool		True False
+syn region  laceString		start=+"+ skip=+%"+ end=+"+ contains=laceEscape,laceStringError
+syn match   laceEscape		contained "%[^/]"
+syn match   laceEscape		contained "%/\d\+/"
+syn match   laceEscape		contained "^[ \t]*%"
+syn match   laceEscape		contained "%[ \t]*$"
+syn match   laceStringError	contained "%/[^0-9]"
+syn match   laceStringError	contained "%/\d\+[^0-9/]"
+syn match   laceStringError	"'\(%[^/]\|%/\d\+/\|[^'%]\)\+'"
+syn match   laceCharacter	"'\(%[^/]\|%/\d\+/\|[^'%]\)'" contains=laceEscape
+syn match   laceNumber		"-\=\<\d\+\(_\d\+\)*\>"
+syn match   laceNumber		"\<[01]\+[bB]\>"
+syn match   laceNumber		"-\=\<\d\+\(_\d\+\)*\.\(\d\+\(_\d\+\)*\)\=\([eE][-+]\=\d\+\(_\d\+\)*\)\="
+syn match   laceNumber		"-\=\.\d\+\(_\d\+\)*\([eE][-+]\=\d\+\(_\d\+\)*\)\="
+syn match   laceComment		"--.*" contains=laceTodo
+
+
+syn case match
+
+" Case sensitive stuff
+
+syn keyword laceTodo		TODO XXX FIXME
+syn match	laceClassName	"\<[A-Z][A-Z0-9_]*\>"
+syn match	laceCluster		"[a-zA-Z][a-zA-Z0-9_]*\s*:"
+syn match	laceCluster		"[a-zA-Z][a-zA-Z0-9_]*\s*(\s*[a-zA-Z][a-zA-Z0-9_]*\s*)\s*:"
+
+" Catch mismatched parentheses
+syn match laceParenError	")"
+syn match laceBracketError	"\]"
+syn region laceGeneric		transparent matchgroup=laceBrackets start="\[" end="\]" contains=ALLBUT,laceBracketError
+syn region laceParen		transparent start="(" end=")" contains=ALLBUT,laceParenError
+
+" Should suffice for even very long strings and expressions
+syn sync lines=40
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_lace_syntax_inits")
+  if version < 508
+    let did_lace_syntax_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  HiLink laceTopStruct			PreProc
+
+  HiLink laceOptionClause		Statement
+  HiLink laceOptionMark			Constant
+  HiLink laceClusterProp		Label
+  HiLink laceAdaptClassName		Label
+  HiLink laceExternal			Statement
+  HiLink laceCluster			ModeMsg
+
+  HiLink laceEscape				Special
+
+  HiLink laceBool				Boolean
+  HiLink laceString				String
+  HiLink laceCharacter			Character
+  HiLink laceClassName			Type
+  HiLink laceNumber				Number
+
+  HiLink laceOperator			Special
+  HiLink laceArray				Special
+  HiLink laceExport				Special
+  HiLink laceCreation			Special
+  HiLink laceBrackets			Special
+  HiLink laceConstraint			Special
+
+  HiLink laceComment			Comment
+
+  HiLink laceError				Error
+  HiLink laceStringError		Error
+  HiLink laceParenError			Error
+  HiLink laceBracketError		Error
+  HiLink laceTodo				Todo
+
+  delcommand HiLink
+endif
+
+let b:current_syntax = "lace"
+
+" vim: ts=4


### PR DESCRIPTION
It would be nice if we could keep all the officially distributed Eiffel-related runtime files in the same repo.

Here's two of mine - a general filetype plugin and a compiler plugin for Liberty Eiffel's se compile command.  It looks like you left out your LACE syntax file which is still used with Liberty so I've included that as well.

